### PR TITLE
Added eco device auto discovery during startup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules/
 udp_serv.js
 multicast.js
+publish.sh

--- a/README.md
+++ b/README.md
@@ -31,6 +31,10 @@ Configuration sample:
             }
         ]
 ```
+## Optional parameters
+
+- debug, this will enable more logging information from the plugin
+  "debug": "True"
 
 #Credits
 

--- a/README.md
+++ b/README.md
@@ -3,8 +3,9 @@
 
 This plugin allows you to remotely control the state of your Eco Plug.  It allows
 you to set the on/off state.  This plugin supports device auto discovery, and
-will scan the network during startup for 1.5 seconds and add all discovered devices.
-It will also remove any devices not responding during startup.
+will scan the network for new devices every 60 seconds and add new devices.  To
+remove devices that are no longer responding, use the 'Identify Accessory' button
+on the accessory page of settings on Eve.  It will remove non-responding accessories.
 
 # Tested devices
 

--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ Configuration sample:
 ## Optional parameters
 
 - debug, this will enable more logging information from the plugin
+
   "debug": "True"
 
 #Credits

--- a/README.md
+++ b/README.md
@@ -1,7 +1,15 @@
 # homebridge-ecoplug
 [Homebridge](https://github.com/nfarina/homebridge) platform plugin for Eco smart plugs
 
-This plugin allows you to remotely control the state of your Eco Plug.  It allows you to set the on/off state.
+This plugin allows you to remotely control the state of your Eco Plug.  It allows
+you to set the on/off state.  This plugin supports device auto discovery, and
+will scan the network during startup for 1.5 seconds and add all discovered devices.
+It will also remove any devices not responding during startup.
+
+# Tested devices
+
+- ECO Plugs CT-65W Wi-Fi Controlled Outlet
+- Woods WiOn 50052 WiFi In-Wall Light Switch
 
 # Installation
 
@@ -17,29 +25,12 @@ Configuration sample:
         "platforms": [
             {
                 "platform": "EcoPlug",
-                "name": "EcoPlug",
-                "plugs": [
-                    {
-                        "name": "EcoPlug1",
-                        "host": "192.168.0.xxx",
-                        "id": "ECO-xxxxxxxx"
-                    },
-                    {
-                        "name": "EcoPlug2",
-                        "host": "192.168.0.yyy",
-                        "id": "ECO-yyyyyyyy"                        
-                    }
-                ]
+                "name": "EcoPlug"
+
             }
         ]
 ```
 
-| Fields   | Description | Required |
-|----------|--------------------------------------------------------------------|:---:|
-| platform | Must always be `EcoPlug`                                           | Yes |
-| name     | The name of your platform. Shows up in the logs                    | Yes |
-| plugs    | Subsection to define individual plugs                              | Yes |
-|          | *Fields for plugs subsection*                                      |     |
-| name     | The name of your plug                                              | Yes |
-| host     | The hostname or ip of the EcoPlug                                  | Yes |
-| id       | The id of the Eco Plug as shown in the ECO app under settings      | Yes |
+#Credits
+
+- NorthernMan54 - Added device auto discovery

--- a/index.js
+++ b/index.js
@@ -1,15 +1,16 @@
 "use strict";
 
+var eco = require('./lib/eco.js');
 var Accessory, Service, Characteristic, UUIDGen;
-var dgram = require('dgram');
+//var dgram = require('dgram');
 
-module.exports = function (homebridge) {
+module.exports = function(homebridge) {
 
     Accessory = homebridge.platformAccessory;
     Service = homebridge.hap.Service;
     Characteristic = homebridge.hap.Characteristic;
     UUIDGen = homebridge.hap.uuid;
-    
+
     homebridge.registerPlatform("homebridge-ecoplugs", "EcoPlug", EcoPlugPlatform);
 }
 
@@ -26,34 +27,51 @@ function EcoPlugPlatform(log, config, api) {
     }
 }
 
-EcoPlugPlatform.prototype.configureAccessory = function (accessory) {
+EcoPlugPlatform.prototype.configureAccessory = function(accessory) {
     var accessoryId = accessory.context.id;
 
     this.setService(accessory);
     this.accessories[accessoryId] = accessory;
 }
 
-EcoPlugPlatform.prototype.didFinishLaunching = function () {
+EcoPlugPlatform.prototype.didFinishLaunching = function() {
 
-    if (!this.plugs.length) {
-        this.log.error("No plugs configured. Please check your 'config.json' file!");
-    }
-    
-    for (var i in this.plugs) {
-        var data = this.plugs[i];
-        this.log("Adding EcoPlug: " + data.name);
-        this.addAccessory(data);
-    }
+    var that = this;
 
-    for (var id in this.accessories) {
-        var plug = this.accessories[id];
-        if (!plug.reachable) {
-            this.removeAccessory(plug);
+    eco.discovery(that, function(err, devices) {
+
+        this.log("Adding discovered devices");
+
+        for (var i in devices) {
+            this.log("Adding EcoPlug: ", devices[i].name);
+            this.addAccessory(devices[i]);
         }
-    }
+
+        for (var id in this.accessories) {
+            var plug = this.accessories[id];
+            if (!plug.reachable) {
+                this.removeAccessory(plug);
+            }
+        }
+
+        this.log("Adding complete");
+
+    }.bind(that));
+
+    //    if (!this.plugs.length) {
+    //        this.log.error("No plugs configured. Please check your 'config.json' file!");
+    //    }
+
+    //    for (var i in this.plugs) {
+    //        var data = this.plugs[i];
+    //        this.log("Adding EcoPlug: " + data.name);
+    //        this.addAccessory(data);
+    //    }
+
+
 }
 
-EcoPlugPlatform.prototype.addAccessory = function (data) {
+EcoPlugPlatform.prototype.addAccessory = function(data) {
     if (!this.accessories[data.id]) {
         var uuid = UUIDGen.generate(data.id);
 
@@ -65,14 +83,13 @@ EcoPlugPlatform.prototype.addAccessory = function (data) {
         newAccessory.context.host = data.host;
         newAccessory.context.port = 80;
         newAccessory.context.id = data.id;
-        
+
         newAccessory.addService(Service.Switch, data.name);
 
         this.setService(newAccessory);
-        
+
         this.api.registerPlatformAccessories("homebridge-ecoplugs", "EcoPlug", [newAccessory]);
-    }
-    else {
+    } else {
         var newAccessory = this.accessories[data.id];
 
         newAccessory.updateReachability(true);
@@ -83,7 +100,7 @@ EcoPlugPlatform.prototype.addAccessory = function (data) {
     this.accessories[data.id] = newAccessory;
 }
 
-EcoPlugPlatform.prototype.removeAccessory = function (accessory) {
+EcoPlugPlatform.prototype.removeAccessory = function(accessory) {
     if (accessory) {
         var name = accessory.context.name;
         var id = accessory.context.id;
@@ -93,7 +110,7 @@ EcoPlugPlatform.prototype.removeAccessory = function (accessory) {
     }
 }
 
-EcoPlugPlatform.prototype.setService = function (accessory) {
+EcoPlugPlatform.prototype.setService = function(accessory) {
     accessory.getService(Service.Switch)
         .getCharacteristic(Characteristic.On)
         .on('set', this.setPowerState.bind(this, accessory.context))
@@ -102,7 +119,7 @@ EcoPlugPlatform.prototype.setService = function (accessory) {
     accessory.on('identify', this.identify.bind(this, accessory.context));
 }
 
-EcoPlugPlatform.prototype.getInitState = function (accessory, data) {
+EcoPlugPlatform.prototype.getInitState = function(accessory, data) {
     var info = accessory.getService(Service.AccessoryInformation);
 
     accessory.context.manufacturer = "ECO Plugs";
@@ -118,12 +135,13 @@ EcoPlugPlatform.prototype.getInitState = function (accessory, data) {
         .getValue();
 }
 
-EcoPlugPlatform.prototype.setPowerState = function (thisPlug, powerState, callback) {
+EcoPlugPlatform.prototype.setPowerState = function(thisPlug, powerState, callback) {
+    var that = this;
 
-    var message = this.createMessage('set', thisPlug.id, powerState);
+    var message = eco.createMessage('set', thisPlug.id, powerState);
     var retry_count = 3;
 
-    this.sendMessage(message, thisPlug, retry_count, function (err, message) {
+    eco.sendMessage(that,message, thisPlug, retry_count, function(err, message) {
         if (!err) {
             this.log("Setting %s switch with ID %s to: %s", thisPlug.name, thisPlug.id, (powerState ? "ON" : "OFF"));
         }
@@ -132,14 +150,15 @@ EcoPlugPlatform.prototype.setPowerState = function (thisPlug, powerState, callba
 
 }
 
-EcoPlugPlatform.prototype.getPowerState = function (thisPlug, callback) {
+EcoPlugPlatform.prototype.getPowerState = function(thisPlug, callback) {
+    var that = this;
 
     var status = false;
 
-    var message = this.createMessage('get', thisPlug.id);
+    var message = eco.createMessage('get', thisPlug.id);
     var retry_count = 3;
 
-    this.sendMessage(message, thisPlug, retry_count, function (err, message) {
+    eco.sendMessage(that,message, thisPlug, retry_count, function(err, message) {
         if (!err) {
             status = this.readState(message);
             this.log("Status of %s switch with ID %s is: %s", thisPlug.name, thisPlug.id, (status ? "ON" : "OFF"));
@@ -149,118 +168,118 @@ EcoPlugPlatform.prototype.getPowerState = function (thisPlug, callback) {
 
 }
 
-EcoPlugPlatform.prototype.identify = function (thisPlug, paired, callback) {
-  this.log("Identify requested for " + thisPlug.name);
-  callback();
+EcoPlugPlatform.prototype.identify = function(thisPlug, paired, callback) {
+    this.log("Identify requested for " + thisPlug.name);
+    callback();
 }
 
-EcoPlugPlatform.prototype.createMessage = function (command, id, state) {
+//EcoPlugPlatform.prototype.createMessage = function (command, id, state) {
 
-    var bufferLength;
-    var command1;
-    var command2;
-    var new_state;
+//    var bufferLength;
+//    var command1;
+//    var command2;
+//    var new_state;
 
-    if (command == 'set') {
-        bufferLength = 130;
-        command1 = 0x16000500;
-        command2 = 0x0200;
-        if (state) {
-            new_state = 0x0101;
-        } else {
-            new_state = 0x0100;
-        }
-    }
-    else if (command == 'get') {
-        bufferLength = 128;
-        command1 = 0x17000500;
-        command2 = 0x0000;
-    }
-    else {
-        throw err;
-    }
+//    if (command == 'set') {
+//        bufferLength = 130;
+//        command1 = 0x16000500;
+//        command2 = 0x0200;
+//        if (state) {
+//            new_state = 0x0101;
+//        } else {
+//            new_state = 0x0100;
+//        }
+//    }
+//    else if (command == 'get') {
+//        bufferLength = 128;
+//        command1 = 0x17000500;
+//        command2 = 0x0000;
+//    }
+//    else {
+//        throw err;
+//    }
 
-    var buffer = new Buffer(bufferLength);
+//    var buffer = new Buffer(bufferLength);
 
-    buffer.fill(0);
+//    buffer.fill(0);
 
-    // Byte 0:3 - Command 0x16000500 = Write, 0x17000500 = Read
-    buffer.writeUInt32BE(command1, 0);
-    
-    // Byte 4:7 - Command sequence num - looks random
-    buffer.writeUInt32BE(Math.floor(Math.random() * 0xFFFF), 4);
+// Byte 0:3 - Command 0x16000500 = Write, 0x17000500 = Read
+//    buffer.writeUInt32BE(command1, 0);
 
-    // Byte 8:9 - Not sure what this field is - 0x0200 = Write, 0x0000 = Read
-    buffer.writeUInt16BE(command2, 8);
+// Byte 4:7 - Command sequence num - looks random
+//    buffer.writeUInt32BE(Math.floor(Math.random() * 0xFFFF), 4);
 
-    // Byte 10:14 - ASCII encoded FW Version - Set in readback only?
-    
-    // Byte 15 - Always 0x0
-    
-    // Byte 16:31 - ECO Plugs ID ASCII Encoded - <ECO-xxxxxxxx>
-    buffer.write(id, 16, 16);
+// Byte 8:9 - Not sure what this field is - 0x0200 = Write, 0x0000 = Read
+//    buffer.writeUInt16BE(command2, 8);
 
-    // Byte 32:47 - 0's - Possibly extension of Plug ID
-    
-    // Byte 48:79 - ECO Plugs name as set in app
-    
-    // Byte 80:95 - ECO Plugs ID without the 'ECO-' prefix - ASCII Encoded
-    
-    // Byte 96:111 - 0's
-    
-    // Byte 112:115 - Something gets returned here during readback - not sure
-    
-    // Byte 116:119 - The current epoch time in Little Endian
-    buffer.writeUInt32LE((Math.floor(new Date() / 1000)), 116);
-    
-    // Byte 120:123 - 0's
-    
-    // Byte 124:127 - Not sure what this field is - this value works, but i've seen others 0xCDB8422A
-    buffer.writeUInt32BE(0xCDB8422A, 124);
-    
-    // Byte 128:129 - Power state (only for writes)
-    if (buffer.length == 130) {
-        buffer.writeUInt16BE(new_state, 128);
-    }
+// Byte 10:14 - ASCII encoded FW Version - Set in readback only?
 
-    return buffer;
-}
+// Byte 15 - Always 0x0
 
-EcoPlugPlatform.prototype.sendMessage = function (message, thisPlug, retry_count, callback) {
+// Byte 16:31 - ECO Plugs ID ASCII Encoded - <ECO-xxxxxxxx>
+//    buffer.write(id, 16, 16);
 
-    var socket = dgram.createSocket('udp4');
-    var timeout;
+// Byte 32:47 - 0's - Possibly extension of Plug ID
 
-    socket.on('message', function (message) {
-        clearTimeout(timeout);
-        socket.close();
-        callback(null, message);
-    }.bind(this));
+//    // Byte 48:79 - ECO Plugs name as set in app
 
-    socket.send(message, 0, message.length, thisPlug.port, thisPlug.host, function (err, bytes) {
-        if (err) {
-            callback(err);
-        } else {
-            timeout = setTimeout(function () {
-                socket.close();
-                if (retry_count > 0) {
-                    this.log.warn("Timeout connecting to %s - Retrying....", thisPlug.host);
-                    var cnt = retry_count - 1;
-                    this.sendMessage(message, thisPlug, cnt, callback);
-                } else {
-                    this.log.error("Timeout connecting to %s - Failing", thisPlug.host);
-                    callback(true);
-                }
-            }.bind(this), 500);
-        }
-    }.bind(this));
+//    // Byte 80:95 - ECO Plugs ID without the 'ECO-' prefix - ASCII Encoded
 
-}
+// Byte 96:111 - 0's
 
-EcoPlugPlatform.prototype.readState = function (message) {
+// Byte 112:115 - Something gets returned here during readback - not sure
+
+// Byte 116:119 - The current epoch time in Little Endian
+//    buffer.writeUInt32LE((Math.floor(new Date() / 1000)), 116);
+
+// Byte 120:123 - 0's
+
+// Byte 124:127 - Not sure what this field is - this value works, but i've seen others 0xCDB8422A
+//    buffer.writeUInt32BE(0xCDB8422A, 124);
+
+// Byte 128:129 - Power state (only for writes)
+//    if (buffer.length == 130) {
+//        buffer.writeUInt16BE(new_state, 128);
+//    }
+
+//    return buffer;
+//}
+
+//EcoPlugPlatform.prototype.sendMessage = function (message, thisPlug, retry_count, callback) {
+
+//    var socket = dgram.createSocket('udp4');
+//    var timeout;
+
+//    socket.on('message', function (message) {
+//        clearTimeout(timeout);
+//        socket.close();
+//        callback(null, message);
+//    }.bind(this));
+
+//    socket.send(message, 0, message.length, thisPlug.port, thisPlug.host, function (err, bytes) {
+//        if (err) {
+//            callback(err);
+//        } else {
+//            timeout = setTimeout(function () {
+//                socket.close();
+//                if (retry_count > 0) {
+//                    this.log.warn("Timeout connecting to %s - Retrying....", thisPlug.host);
+//                    var cnt = retry_count - 1;
+//                    this.sendMessage(message, thisPlug, cnt, callback);
+//                } else {
+//                    this.log.error("Timeout connecting to %s - Failing", thisPlug.host);
+//                    callback(true);
+//                }
+//            }.bind(this), 500);
+//        }
+//    }.bind(this));
+
+//}
+
+EcoPlugPlatform.prototype.readState = function(message) {
     return (message.readUInt8(129)) ? true : false;
 }
 
-EcoPlugPlatform.prototype.readName = function (message) {
+EcoPlugPlatform.prototype.readName = function(message) {
     return (message.toString('ascii', 48, 79));
 }

--- a/lib/eco.js
+++ b/lib/eco.js
@@ -1,0 +1,303 @@
+var dgram = require('dgram');
+var Parser = require('binary-parser').Parser;
+
+exports.discovery = function(that, callback) {
+
+    var devices;
+
+    sendDiscoveryMessage(createDiscoveryMessage(), function(err, devices) {
+        if (!err) {
+
+            callback(null, devices);
+            //            that.log("Status of %s switch with ID %s is: %s", thisPlug.name, thisPlug.id, (status ? "ON" : "OFF"));
+        } else {
+            that.log("Error", err);
+            callback(err);
+        }
+
+    }.bind(this));
+
+}
+
+
+sendDiscoveryMessage = function(message, callback) {
+
+    var socket = dgram.createSocket('udp4');
+    var timeout;
+
+    var discovered = [];
+
+
+    socket.bind(9000);
+
+    socket.on('listening', function() {
+        socket.setBroadcast(true);
+    });
+
+    socket.on('message', function(message) {
+        device = parseDiscoveryResponse(message);
+        //        console.log("Parsed device",device);
+        discovered[device.id] = device;
+
+    }.bind(this));
+
+
+    socket.send(message, 0, 128, 25, "255.255.255.255", function(err, bytes) {
+        if (err) {
+            callback(err);
+        } else {
+            timeout = setTimeout(function() {
+                socket.close();
+
+                callback(null, discovered);
+
+            }.bind(this), 1500);
+        }
+    }.bind(this));
+}
+
+
+exports.sendMessage = function(that, message, thisPlug, retry_count, callback) {
+
+    var socket = dgram.createSocket('udp4');
+    var timeout;
+
+    socket.on('message', function(message) {
+        clearTimeout(timeout);
+        socket.close();
+        callback(null, message);
+    }.bind(this));
+
+    socket.send(message, 0, message.length, thisPlug.port, thisPlug.host, function(err, bytes) {
+        if (err) {
+            callback(err);
+        } else {
+            timeout = setTimeout(function() {
+                socket.close();
+                if (retry_count > 0) {
+                    that.log.warn("Timeout connecting to %s - Retrying....", thisPlug.host);
+                    var cnt = retry_count - 1;
+                    this.sendMessage(that, message, thisPlug, cnt, callback);
+                } else {
+                    that.log.error("Timeout connecting to %s - Failing", thisPlug.host);
+                    callback(true);
+                }
+            }.bind(this), 500);
+        }
+    }.bind(this));
+
+}
+
+exports.createMessage = function(command, id, state) {
+
+    var bufferLength;
+    var command1;
+    var command2;
+    var new_state;
+
+    if (command == 'set') {
+        bufferLength = 130;
+        command1 = 0x16000500;
+        command2 = 0x0200;
+        if (state) {
+            new_state = 0x0101;
+        } else {
+            new_state = 0x0100;
+        }
+    } else if (command == 'get') {
+        bufferLength = 128;
+        command1 = 0x17000500;
+        command2 = 0x0000;
+    } else {
+        throw err;
+    }
+
+    var buffer = new Buffer(bufferLength);
+
+    buffer.fill(0);
+
+    // Byte 0:3 - Command 0x16000500 = Write, 0x17000500 = Read
+    buffer.writeUInt32BE(command1, 0);
+
+    // Byte 4:7 - Command sequence num - looks random
+    buffer.writeUInt32BE(Math.floor(Math.random() * 0xFFFF), 4);
+
+    // Byte 8:9 - Not sure what this field is - 0x0200 = Write, 0x0000 = Read
+    buffer.writeUInt16BE(command2, 8);
+
+    // Byte 10:14 - ASCII encoded FW Version - Set in readback only?
+
+    // Byte 15 - Always 0x0
+
+    // Byte 16:31 - ECO Plugs ID ASCII Encoded - <ECO-xxxxxxxx>
+    buffer.write(id, 16, 16);
+
+    // Byte 32:47 - 0's - Possibly extension of Plug ID
+
+    // Byte 48:79 - ECO Plugs name as set in app
+
+    // Byte 80:95 - ECO Plugs ID without the 'ECO-' prefix - ASCII Encoded
+
+    // Byte 96:111 - 0's
+
+    // Byte 112:115 - Something gets returned here during readback - not sure
+
+    // Byte 116:119 - The current epoch time in Little Endian
+    buffer.writeUInt32LE((Math.floor(new Date() / 1000)), 116);
+
+    // Byte 120:123 - 0's
+
+    // Byte 124:127 - Not sure what this field is - this value works, but i've seen others 0xCDB8422A
+    buffer.writeUInt32BE(0xCDB8422A, 124);
+
+    // Byte 128:129 - Power state (only for writes)
+    if (buffer.length == 130) {
+        buffer.writeUInt16BE(new_state, 128);
+    }
+
+    return buffer;
+}
+
+function parseDiscoveryResponse(message) {
+
+    //    console.log(message);
+
+    var discoveryResponse = new Parser()
+        .skip(4)
+        .string('version', {
+            encoding: 'ascii',
+            length: 6,
+            stripNull: true
+        })
+        .string('id', {
+            encoding: 'ascii',
+            length: 32,
+            stripNull: true
+        })
+        .string('name', {
+            encoding: 'ascii',
+            length: 32,
+            stripNull: true
+        })
+        .string('shortid', {
+            encoding: 'ascii',
+            length: 34,
+            stripNull: true
+        })
+        .array('time', {
+            type: 'uint8',
+            length: 12
+        })
+        .string('SSID', {
+            encoding: 'ascii',
+            length: 24,
+            stripNull: true
+        })
+        .array('data2', {
+            type: 'uint8',
+            length: 16
+        })
+        .array('data3', {
+            type: 'uint8',
+            length: 16
+        })
+        .array('data3a', {
+            type: 'uint8',
+            length: 8
+        })
+        .string('password', {
+            encoding: 'ascii',
+            length: 24,
+            stripNull: true
+        })
+        .array('data4', {
+            type: 'uint8',
+            length: 10
+        })
+        .array('data4a', {
+            type: 'uint8',
+            length: 4
+        })
+        .string('string2', {
+            encoding: 'ascii',
+            length: 18,
+            stripNull: true
+        })
+        .array('data5', {
+            type: 'uint8',
+            length: 12
+        })
+        .string('region', {
+            encoding: 'ascii',
+            length: 8,
+            stripNull: true
+        })
+        .string('areacode', {
+            encoding: 'ascii',
+            length: 4,
+            stripNull: true
+        })
+        .string('a', {
+            encoding: 'ascii',
+            length: 8,
+            stripNull: true
+        })
+        .string('ipa', {
+            encoding: 'ascii',
+            length: 16,
+            stripNull: true
+        })
+        .string('ipb', {
+            encoding: 'ascii',
+            length: 16,
+            stripNull: true
+        })
+        .string('ipc', {
+            encoding: 'ascii',
+            length: 16,
+            stripNull: true
+        })
+        .array('data6', {
+            type: 'uint8',
+            length: 18
+        })
+        .string('string3', {
+            encoding: 'ascii',
+            length: 30,
+            stripNull: true
+        })
+        .string('mac', {
+            encoding: 'ascii',
+            length: 18,
+            stripNull: true
+        })
+        .string('host', {
+            encoding: 'ascii',
+            length: 18,
+            stripNull: true
+        })
+        .array('data7', {
+            type: 'uint8',
+            length: 3
+        })
+        .buffer('remaining', {
+            clone: true,
+            readUntil: 'eof'
+        });
+
+    response = discoveryResponse.parse(message);
+
+    if (response.name == "")
+        response.name = response.id;
+    return response;
+}
+
+function createDiscoveryMessage() {
+    var message = new Buffer(128);
+
+    message.fill(0);
+    message.writeUInt32BE("0x00e0070b", 23);
+    message.writeUInt32BE("0x11f79d00", 27);
+
+    return message;
+}

--- a/lib/eco.js
+++ b/lib/eco.js
@@ -1,57 +1,73 @@
 var dgram = require('dgram');
 var Parser = require('binary-parser').Parser;
+var socket = dgram.createSocket('udp4');
+var discovered = [];
 
-exports.discovery = function(that, callback) {
-
-    var devices;
-
-    sendDiscoveryMessage(createDiscoveryMessage(), function(err, devices) {
-        if (!err) {
-
-            callback(null, devices);
-            //            that.log("Status of %s switch with ID %s is: %s", thisPlug.name, thisPlug.id, (status ? "ON" : "OFF"));
-        } else {
-            that.log("Error", err);
-            callback(err);
-        }
-
-    }.bind(this));
-
-}
-
-
-sendDiscoveryMessage = function(message, callback) {
-
-    var socket = dgram.createSocket('udp4');
-    var timeout;
-
-    var discovered = [];
-
-
+exports.startUdpServer = function(that, callback) {
     socket.bind(9000);
-
     socket.on('listening', function() {
         socket.setBroadcast(true);
     });
 
     socket.on('message', function(message) {
-        device = parseDiscoveryResponse(message);
-        //        console.log("Parsed device",device);
-        discovered[device.id] = device;
-
+        switch (message.length) {
+            case 408:
+                // Device discovery response
+                device = _parse408Message(message);
+                discovered[device.id] = device;
+                //                console.log("408",device.shortid,device.remaining);
+                break;
+            case 130:
+                // getStatus response
+                action = _parse130Message(message);
+                callback(action);
+                break;
+            case 128:
+                // setPower response, what do I do with this?
+                action = _parse128Message(message);
+                //                console.log("128", action.shortid,action.command1, action.model, action.unknown1, action.remaining);
+                //                that.log("128", action.remaining.toString());
+                break;
+            default:
+                that.log("Unknown ECO Message", message.length);
+                that.log("Message", message);
+                that.log("Message", message.toString());
+        }
     }.bind(this));
+    return socket;
+}
 
+exports.discovery = function(that, callback) {
+    var devices;
+
+    discovered = [];
+    _sendDiscoveryMessage(createDiscoveryMessage(), 3,function(err, devices) {
+        if (!err) {
+            callback(null, devices);
+        } else {
+            that.log("Error", err);
+            callback(err);
+        }
+    }.bind(this));
+}
+
+
+_sendDiscoveryMessage = function(message, retry_count, callback) {
+    var timeout;
 
     socket.send(message, 0, 128, 25, "255.255.255.255", function(err, bytes) {
         if (err) {
             callback(err);
         } else {
             timeout = setTimeout(function() {
-                socket.close();
+                if (retry_count > 1) {
+                    var cnt = retry_count - 1;
 
-                callback(null, discovered);
-
-            }.bind(this), 1500);
+                    this._sendDiscoveryMessage( message, cnt, callback);
+                } else {
+                    callback(null, discovered);
+                }
+            }.bind(this), 500);
         }
     }.bind(this));
 }
@@ -59,28 +75,21 @@ sendDiscoveryMessage = function(message, callback) {
 
 exports.sendMessage = function(that, message, thisPlug, retry_count, callback) {
 
-    var socket = dgram.createSocket('udp4');
     var timeout;
 
-    socket.on('message', function(message) {
-        clearTimeout(timeout);
-        socket.close();
-        callback(null, message);
-    }.bind(this));
-
     socket.send(message, 0, message.length, thisPlug.port, thisPlug.host, function(err, bytes) {
+
         if (err) {
             callback(err);
         } else {
             timeout = setTimeout(function() {
-                socket.close();
-                if (retry_count > 0) {
-                    that.log.warn("Timeout connecting to %s - Retrying....", thisPlug.host);
+                //socket.close();
+                if (retry_count > 1) {
+
                     var cnt = retry_count - 1;
                     this.sendMessage(that, message, thisPlug, cnt, callback);
                 } else {
-                    that.log.error("Timeout connecting to %s - Failing", thisPlug.host);
-                    callback(true);
+                    callback(false);
                 }
             }.bind(this), 500);
         }
@@ -158,9 +167,99 @@ exports.createMessage = function(command, id, state) {
     return buffer;
 }
 
-function parseDiscoveryResponse(message) {
+function _parse130Message(message) {
+    var response = new Parser()
+        .buffer('command1', {
+            clone: true,
+            length: 6
+        })
+        .buffer('model', {
+            clone: true,
+            length: 4
+        })
+        .string('version', {
+            encoding: 'ascii',
+            length: 6,
+            stripNull: true
+        })
+        .string('id', {
+            encoding: 'ascii',
+            length: 32,
+            stripNull: true
+        })
+        .string('name', {
+            encoding: 'ascii',
+            length: 32,
+            stripNull: true
+        })
+        .string('shortid', {
+            encoding: 'ascii',
+            length: 32,
+            stripNull: true
+        })
+        .buffer('unknown1', {
+            clone: false,
+            length: 12
+        })
+        .buffer('unsure', {
+            clone: false,
+            length: 5
+        })
+        .uint8('status')
+        .array('remaining', {
+            type: 'uint8',
+            readUntil: 'eof',
+            formatter: (a) => Buffer(a)
+        });
 
-    //    console.log(message);
+    return response.parse(message);
+}
+
+function _parse128Message(message) {
+    var response = new Parser()
+        .buffer('command1', {
+            clone: true,
+            length: 6
+        })
+        .buffer('model', {
+            clone: true,
+            length: 4
+        })
+        .string('version', {
+            encoding: 'ascii',
+            length: 6,
+            stripNull: true
+        })
+        .string('id', {
+            encoding: 'ascii',
+            length: 32,
+            stripNull: true
+        })
+        .string('name', {
+            encoding: 'ascii',
+            length: 32,
+            stripNull: true
+        })
+        .string('shortid', {
+            encoding: 'ascii',
+            length: 32,
+            stripNull: true
+        })
+        .buffer('unknown1', {
+            clone: true,
+            length: 12
+        })
+        .array('remaining', {
+            type: 'uint8',
+            readUntil: 'eof',
+            formatter: (a) => Buffer(a)
+        });
+
+    return response.parse(message);
+}
+
+
+function _parse408Message(message) {
 
     var discoveryResponse = new Parser()
         .skip(4)
@@ -181,12 +280,12 @@ function parseDiscoveryResponse(message) {
         })
         .string('shortid', {
             encoding: 'ascii',
-            length: 34,
+            length: 32,
             stripNull: true
         })
         .array('time', {
             type: 'uint8',
-            length: 12
+            length: 14
         })
         .string('SSID', {
             encoding: 'ascii',
@@ -280,9 +379,10 @@ function parseDiscoveryResponse(message) {
             type: 'uint8',
             length: 3
         })
-        .buffer('remaining', {
-            clone: true,
-            readUntil: 'eof'
+        .array('remaining', {
+            type: 'uint8',
+            readUntil: 'eof',
+            formatter: (a) => Buffer(a)
         });
 
     response = discoveryResponse.parse(message);

--- a/package.json
+++ b/package.json
@@ -15,6 +15,9 @@
     "node": ">=0.12.0",
     "homebridge": ">=0.3.0"
   },
+  "dependencies": {
+    "binary-parser": "~1.1.5"
+  }
   "main": "index.js",
   "author": "Dan Chlopek"
 }

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   },
   "dependencies": {
     "binary-parser": "~1.1.5"
-  }
+  },
   "main": "index.js",
   "author": "Dan Chlopek"
 }


### PR DESCRIPTION
Hi,

This is a first draft of an attempt of implementing device auto discovery, as I really dislike editing config files.   I also split the eco specific code into a separate library to make it easier to maintain and follow the homebridge flows.

I would suggest trying this out for a few days before publishing as the production version.

For the device auto discovery, the app is just broadcasting a message of 128 bytes, with a 6 byte value starting at byte 24.   On the first try it didn't seem to care about what the value was so I hard coded it.  Will need to watch this and see what happens over time.

When I parsed out the discovery response packet, I couldn't find a device model field.  As I have outlets and wall switches, I thought it would be useful map this to the appropriate home kit device.

On my roadmap of further changes will be looking into status polling, and look into either implementing a polling routine, or determining if the device broadcasts changes.  When looking at the network sniffer the device is very chatty, so it may be sending updates.

Also on the roadmap will be updating the device auto discovery to discovery devices at any time, and not just at startup.   I have this already working in a different plugin, so will be straight forward to port.  The plugin with this is homebridge-mcuiot.

