### PR TITLE
Fixed stability issues when modules aren't reachable on the network.

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,9 +32,7 @@ Configuration sample:
 ```
 ## Optional parameters
 
-- debug, this will enable more logging information from the plugin
-
-  "debug": "True"
+- None
 
 #Credits
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # homebridge-ecoplug
-[Homebridge](https://github.com/nfarina/homebridge) platform plugin for Eco smart plugs
+[Homebridge](https://github.com/nfarina/homebridge) platform plugin for Eco and WION Wi-Fi modules and switches
 
 This plugin allows you to remotely control the state of your Eco Plug.  It allows
 you to set the on/off state.  This plugin supports device auto discovery, and
@@ -14,8 +14,8 @@ on the accessory page of settings on Eve.  It will remove non-responding accesso
 
 # Installation
 
-1. Install homebridge using: npm install -g homebridge
-2. Install this plugin using: npm install -g homebridge-ecoplug
+1. Install homebridge using: sudo npm install -g homebridge
+2. Install this plugin using: sudo npm install -g homebridge-ecoplug
 3. Update your configuration file. See below for a sample.
 
 # Configuration

--- a/index.js
+++ b/index.js
@@ -1,246 +1,248 @@
+// Sample Configuration
+//"platforms": [
+//    {
+//        "platform": "EcoPlug",
+//        "name": "EcoPlug"
+//    }
+//]
+
 "use strict";
 
 var eco = require('./lib/eco.js');
-var debug = require('debug')('ECOPLUG');
+var debug = require('debug')('EcoPlug');
 var Accessory, Service, Characteristic, UUIDGen;
 
 module.exports = function(homebridge) {
 
-    Accessory = homebridge.platformAccessory;
-    Service = homebridge.hap.Service;
-    Characteristic = homebridge.hap.Characteristic;
-    UUIDGen = homebridge.hap.uuid;
+  Accessory = homebridge.platformAccessory;
+  Service = homebridge.hap.Service;
+  Characteristic = homebridge.hap.Characteristic;
+  UUIDGen = homebridge.hap.uuid;
 
-    homebridge.registerPlatform("homebridge-ecoplugs", "EcoPlug", EcoPlugPlatform);
+  homebridge.registerPlatform("homebridge-ecoplugs", "EcoPlug", EcoPlugPlatform);
 }
 
 function EcoPlugPlatform(log, config, api) {
-    this.log = log;
-    this.config = config;
-    //    this.plugs = this.config.plugs || [];
-    this.accessories = [];
-    this.cache_timeout = 10; // seconds
+  this.log = log;
+  this.config = config;
+  //    this.plugs = this.config.plugs || [];
+  this.accessories = [];
+  this.cache_timeout = 10; // seconds
 
-    if (api) {
-        this.api = api;
-        this.api.on('didFinishLaunching', this.didFinishLaunching.bind(this));
-    }
+  if (api) {
+    this.api = api;
+    this.api.on('didFinishLaunching', this.didFinishLaunching.bind(this));
+  }
 }
 
 EcoPlugPlatform.prototype.configureAccessory = function(accessory) {
-    var accessoryId = accessory.context.id;
-    this.log("configureAccessory");
-    this.setService(accessory);
-    this.accessories[accessoryId] = accessory;
+  var accessoryId = accessory.context.id;
+  this.log("configureAccessory", accessoryId, accessory.context.name);
+  this.setService(accessory);
+  this.accessories[accessoryId] = accessory;
 }
 
 EcoPlugPlatform.prototype.didFinishLaunching = function() {
-    var that = this;
+  var that = this;
 
-    eco.startUdpServer(this, function(message) {
-        // handle status messages received from devices
+  eco.startUdpServer(this, function(message) {
+    // handle status messages received from devices
 
-            debug("Status: %s %s is: %s", message.id, message.name, (message.status ? "ON" : "OFF"));
-        var accessory = that.accessories[message.id];
+    debug("Status: %s %s is: %s", message.id, message.name, (message.status ? "ON" : "OFF"));
+    var accessory = that.accessories[message.id];
 
-        if (typeof accessory.context.cb === "function") {
-            var cb = accessory.context.cb;
-            accessory.context.cb = false;
-            // this is the callback from the getPowerState
-            cb(null, message.status);
-        } else {
-//            accessory.updateReachability(true);
-            accessory.getService(Service.Outlet)
-                .getCharacteristic(Characteristic.On)
-                .updateValue(message.status);
-        }
-    });
-    this.deviceDiscovery();
-    setInterval(that.devicePolling.bind(that), this.cache_timeout * 1000);
-    setInterval(that.deviceDiscovery.bind(that), this.cache_timeout * 6000);
+    if (typeof accessory.context.cb === "function") {
+      var cb = accessory.context.cb;
+      accessory.context.cb = false;
+      // this is the callback from the getPowerState
+      cb(null, message.status);
+    } else {
+      //            accessory.updateReachability(true);
+      accessory.getService(Service.Outlet)
+        .getCharacteristic(Characteristic.On)
+        .updateValue(message.status);
+    }
+  });
+  this.deviceDiscovery();
+  setInterval(that.devicePolling.bind(that), this.cache_timeout * 1000);
+  setInterval(that.deviceDiscovery.bind(that), this.cache_timeout * 6000);
 }
 
 EcoPlugPlatform.prototype.devicePolling = function() {
-    // Send a return status message every interval
-    for (var id in this.accessories) {
-        var plug = this.accessories[id];
-        if (plug.reachable) {
+  // Send a return status message every interval
+  for (var id in this.accessories) {
+    var plug = this.accessories[id];
 
-                debug("Poll:", id, plug.context.name);
-            this.sendStatusMessage(plug.context);
-        }
-    }
+      debug("Poll:", id, plug.context.name);
+      this.sendStatusMessage(plug.context);
+
+  }
 }
 
 EcoPlugPlatform.prototype.deviceDiscovery = function() {
-    // Send a device discovery message every interval
+  // Send a device discovery message every interval
 
-        debug("Sending device discovery message");
-    eco.discovery(this, function(err, devices) {
+  debug("Sending device discovery message");
+  eco.discovery(this, function(err, devices) {
 
-        if (err) {
-            this.log("ERROR: deviceDisovery", err);
+    if (err) {
+      this.log("ERROR: deviceDisovery", err);
+    } else {
+      debug("Adding discovered devices");
+
+      for (var i in devices) {
+        var existing = this.accessories[devices[i].id];
+        // existing devices are not reachable during a homebridge restart
+        if (!existing ) {
+          this.log("Adding:", devices[i].id, devices[i].name, devices[i].host);
+          this.addAccessory(devices[i]);
         } else {
-            debug("Adding discovered devices");
-
-            for (var i in devices) {
-                var existing = this.accessories[devices[i].id];
-                // existing devices are not reachable during a homebridge restart
-                if (!existing || !existing.reachable) {
-                    this.log("Adding:", devices[i].id, devices[i].name, devices[i].host);
-                    this.addAccessory(devices[i]);
-                } else {
-                    debug("Skipping existing device", i);
-                }
-            }
-            if (devices) {
-                for (var id in this.accessories) {
-                    var found = devices[id];
-                    if (!found) {
-                        this.log("Not found ", id);
-                        this.accessories[id].reachable = false;
-                        // If reachability is false, the identify accessory button doesn't work.
-                        //                this.accessories[id].updateReachability(false);
-                    }
-                }
-            }
+          debug("Skipping existing device", i);
         }
-        debug("Discovery complete");
-    }.bind(this));
+      }
+      if (devices) {
+        for (var id in this.accessories) {
+          var found = devices[id];
+          if (!found) {
+            this.log("Not found ", id);
+          }
+        }
+      }
+    }
+    debug("Discovery complete");
+  }.bind(this));
 }
 
 EcoPlugPlatform.prototype.addAccessory = function(data) {
-    if (!this.accessories[data.id]) {
-        var uuid = UUIDGen.generate(data.id);
+  if (!this.accessories[data.id]) {
+    var uuid = UUIDGen.generate(data.id);
 
-        var newAccessory = new Accessory(data.id, uuid, 8);
+    var newAccessory = new Accessory(data.id, uuid, 8);
 
-        newAccessory.reachable = true;
+    newAccessory.reachable = true;
 
-        newAccessory.context.name = data.name;
-        newAccessory.context.host = data.host;
-        newAccessory.context.port = 80;
-        newAccessory.context.id = data.id;
-        newAccessory.context.cb = false;
+    newAccessory.context.name = data.name;
+    newAccessory.context.host = data.host;
+    newAccessory.context.port = 80;
+    newAccessory.context.id = data.id;
+    newAccessory.context.cb = false;
 
-        newAccessory.addService(Service.Outlet, data.name);
+    newAccessory.addService(Service.Outlet, data.name);
 
-        this.setService(newAccessory);
+    this.setService(newAccessory);
 
-        this.api.registerPlatformAccessories("homebridge-ecoplugs", "EcoPlug", [newAccessory]);
-    } else {
-        var newAccessory = this.accessories[data.id];
+    this.api.registerPlatformAccessories("homebridge-ecoplugs", "EcoPlug", [newAccessory]);
+  } else {
+    var newAccessory = this.accessories[data.id];
 
-//        newAccessory.updateReachability(true);
-    }
+    //        newAccessory.updateReachability(true);
+  }
 
-    this.getInitState(newAccessory, data);
+  this.getInitState(newAccessory, data);
 
-    this.accessories[data.id] = newAccessory;
+  this.accessories[data.id] = newAccessory;
 }
 
 EcoPlugPlatform.prototype.removeAccessory = function(accessory) {
-    if (accessory) {
-        var name = accessory.context.name;
-        var id = accessory.context.id;
-        this.log.warn("Removing EcoPlug: " + name + ". No longer reachable or configured.");
-        this.api.unregisterPlatformAccessories("homebridge-ecoplugs", "EcoPlug", [accessory]);
-        delete this.accessories[id];
-    }
+  if (accessory) {
+    var name = accessory.context.name;
+    var id = accessory.context.id;
+    this.log.warn("Removing EcoPlug: " + name + ". No longer reachable or configured.");
+    this.api.unregisterPlatformAccessories("homebridge-ecoplugs", "EcoPlug", [accessory]);
+    delete this.accessories[id];
+  }
 }
 
 EcoPlugPlatform.prototype.setService = function(accessory) {
-    accessory.getService(Service.Outlet)
-        .getCharacteristic(Characteristic.On)
-        .on('set', this.setPowerState.bind(this, accessory.context))
-        .on('get', this.getPowerState.bind(this, accessory.context));
+  accessory.getService(Service.Outlet)
+    .getCharacteristic(Characteristic.On)
+    .on('set', this.setPowerState.bind(this, accessory.context))
+    .on('get', this.getPowerState.bind(this, accessory.context));
 
-    accessory.on('identify', this.identify.bind(this, accessory.context));
+  accessory.on('identify', this.identify.bind(this, accessory.context));
 }
 
 EcoPlugPlatform.prototype.getInitState = function(accessory, data) {
-    var info = accessory.getService(Service.AccessoryInformation);
+  var info = accessory.getService(Service.AccessoryInformation);
 
-    accessory.context.manufacturer = "ECO Plugs";
-    info.setCharacteristic(Characteristic.Manufacturer, accessory.context.manufacturer);
+  accessory.context.manufacturer = "ECO Plugs";
+  info.setCharacteristic(Characteristic.Manufacturer, accessory.context.manufacturer);
 
-    accessory.context.model = "CT-065W";
-    info.setCharacteristic(Characteristic.Model, accessory.context.model);
+  accessory.context.model = "CT-065W";
+  info.setCharacteristic(Characteristic.Model, accessory.context.model);
 
-    info.setCharacteristic(Characteristic.SerialNumber, accessory.context.id);
+  info.setCharacteristic(Characteristic.SerialNumber, accessory.context.id);
 
-    accessory.getService(Service.Outlet)
-        .getCharacteristic(Characteristic.On)
-        .getValue();
+  accessory.getService(Service.Outlet)
+    .getCharacteristic(Characteristic.On)
+    .getValue();
 }
 
 EcoPlugPlatform.prototype.setPowerState = function(thisPlug, powerState, callback) {
-    var that = this;
+  var that = this;
 
-    if (this.accessories[thisPlug.id] && this.accessories[thisPlug.id].reachable) {
+    var message = eco.createMessage('set', thisPlug.id, powerState);
+    var retry_count = 3;
 
-        var message = eco.createMessage('set', thisPlug.id, powerState);
-        var retry_count = 3;
-
-        eco.sendMessage(that, message, thisPlug, retry_count, function(err, message) {
-            if (!err) {
-                this.log("Setting: %s %s to: %s", thisPlug.id, thisPlug.name, (powerState ? "ON" : "OFF"));
-            }
-            callback();
-        }.bind(this));
-
-    } else {
+    eco.sendMessage(that, message, thisPlug, retry_count, function(err, message) {
+      if (!err) {
+        this.log("Setting: %s %s to: %s", thisPlug.id, thisPlug.name, (powerState ? "ON" : "OFF"));
+        callback();
+      } else {
+        this.log("Error Setting: %s %s to: %s", thisPlug.id, thisPlug.name, (powerState ? "ON" : "OFF"));
         callback(new Error("Device not reachable"));
-    }
+      }
+
+    }.bind(this));
 
 }
 
 
 EcoPlugPlatform.prototype.getPowerState = function(thisPlug, callback) {
 
-    // storing callback with the accessory so that the value can be updated with
-    // the response message
+  // storing callback with the accessory so that the value can be updated with
+  // the response message
 
-    if (this.accessories[thisPlug.id] && this.accessories[thisPlug.id].reachable) {
-        this.log("Getting Status: %s %s", thisPlug.id, thisPlug.name)
-        thisPlug.cb = callback;
-        this.sendStatusMessage(thisPlug);
-    } else {
-        callback(new Error("Device not reachable"));
-    }
+  if (this.accessories[thisPlug.id] && this.accessories[thisPlug.id].reachable) {
+    this.log("Getting Status: %s %s", thisPlug.id, thisPlug.name)
+    thisPlug.cb = callback;
+    this.sendStatusMessage(thisPlug);
+  } else {
+    callback(new Error("Device not reachable"));
+  }
 
 }
 
 EcoPlugPlatform.prototype.sendStatusMessage = function(thisPlug) {
-    // Send a return status message to a device
-    var message = eco.createMessage('get', thisPlug.id);
-    var retry_count = 3;
+  // Send a return status message to a device
+  var message = eco.createMessage('get', thisPlug.id);
+  var retry_count = 3;
 
-    eco.sendMessage(this, message, thisPlug, retry_count, function(err, message) {
-        if (err) {
-            this.log.error("Error: getPowerState", thisPlug.id, err)
-            var cb = thisPlug.cb;
-            if (cb) {
-                thisPlug.cb = false;
-                // this is the callback from the getPowerState
-                cb(err);
-            }
-        }
-    }.bind(this));
+  eco.sendMessage(this, message, thisPlug, retry_count, function(err, message) {
+    if (err) {
+      this.log.error("Error: getPowerState", thisPlug.id, err)
+      var cb = thisPlug.cb;
+      if (cb) {
+        thisPlug.cb = false;
+        // this is the callback from the getPowerState
+        cb(err);
+      }
+    }
+  }.bind(this));
 }
 
 EcoPlugPlatform.prototype.identify = function(thisPlug, paired, callback) {
-    this.log("Identify requested for " + thisPlug.name);
-    if (this.accessories[thisPlug.id] && !this.accessories[thisPlug.id].reachable) {
-        this.removeAccessory(this.accessories[thisPlug.id]);
-    }
-    callback();
+  this.log("Identify requested for " + thisPlug.name);
+  if (this.accessories[thisPlug.id] && !this.accessories[thisPlug.id].reachable) {
+    this.removeAccessory(this.accessories[thisPlug.id]);
+  }
+  callback();
 }
 
 EcoPlugPlatform.prototype.readState = function(message) {
-    return (message.readUInt8(129)) ? true : false;
+  return (message.readUInt8(129)) ? true : false;
 }
 
 EcoPlugPlatform.prototype.readName = function(message) {
-    return (message.toString('ascii', 48, 79));
+  return (message.toString('ascii', 48, 79));
 }

--- a/index.js
+++ b/index.js
@@ -50,7 +50,7 @@ EcoPlugPlatform.prototype.didFinishLaunching = function() {
             // this is the callback from the getPowerState
             cb(null, message.status);
         } else {
-            accessory.updateReachability(true);
+//            accessory.updateReachability(true);
             accessory.getService(Service.Outlet)
                 .getCharacteristic(Characteristic.On)
                 .updateValue(message.status);
@@ -132,7 +132,7 @@ EcoPlugPlatform.prototype.addAccessory = function(data) {
     } else {
         var newAccessory = this.accessories[data.id];
 
-        newAccessory.updateReachability(true);
+//        newAccessory.updateReachability(true);
     }
 
     this.getInitState(newAccessory, data);

--- a/index.js
+++ b/index.js
@@ -1,6 +1,7 @@
 "use strict";
 
 var eco = require('./lib/eco.js');
+var debug = require('debug')('ECOPLUG');
 var Accessory, Service, Characteristic, UUIDGen;
 
 module.exports = function(homebridge) {
@@ -19,8 +20,6 @@ function EcoPlugPlatform(log, config, api) {
     //    this.plugs = this.config.plugs || [];
     this.accessories = [];
     this.cache_timeout = 10; // seconds
-    this.debug = config['debug'] || false;
-
 
     if (api) {
         this.api = api;
@@ -40,8 +39,8 @@ EcoPlugPlatform.prototype.didFinishLaunching = function() {
 
     eco.startUdpServer(this, function(message) {
         // handle status messages received from devices
-        if (that.debug)
-            that.log("Status: %s %s is: %s", message.id, message.name, (message.status ? "ON" : "OFF"));
+
+            debug("Status: %s %s is: %s", message.id, message.name, (message.status ? "ON" : "OFF"));
         var accessory = that.accessories[message.id];
 
         if (typeof accessory.context.cb === "function") {
@@ -66,8 +65,8 @@ EcoPlugPlatform.prototype.devicePolling = function() {
     for (var id in this.accessories) {
         var plug = this.accessories[id];
         if (plug.reachable) {
-            if (this.debug)
-                this.log("Poll:", id, plug.context.name);
+
+                debug("Poll:", id, plug.context.name);
             this.sendStatusMessage(plug.context);
         }
     }
@@ -75,14 +74,14 @@ EcoPlugPlatform.prototype.devicePolling = function() {
 
 EcoPlugPlatform.prototype.deviceDiscovery = function() {
     // Send a device discovery message every interval
-    if (this.debug)
-        this.log("Sending device discovery message");
+
+        debug("Sending device discovery message");
     eco.discovery(this, function(err, devices) {
 
         if (err) {
             this.log("ERROR: deviceDisovery", err);
         } else {
-            if (this.debug) this.log("Adding discovered devices");
+            debug("Adding discovered devices");
 
             for (var i in devices) {
                 var existing = this.accessories[devices[i].id];
@@ -91,7 +90,7 @@ EcoPlugPlatform.prototype.deviceDiscovery = function() {
                     this.log("Adding:", devices[i].id, devices[i].name, devices[i].host);
                     this.addAccessory(devices[i]);
                 } else {
-                    if (this.debug) this.log("Skipping existing device", i);
+                    debug("Skipping existing device", i);
                 }
             }
             if (devices) {
@@ -106,7 +105,7 @@ EcoPlugPlatform.prototype.deviceDiscovery = function() {
                 }
             }
         }
-        if (this.debug) this.log("Discovery complete");
+        debug("Discovery complete");
     }.bind(this));
 }
 

--- a/lib/eco.js
+++ b/lib/eco.js
@@ -82,6 +82,7 @@ exports.sendMessage = function(that, message, thisPlug, retry_count, callback) {
         if (err) {
             callback(err);
         } else {
+//            that.log("No ERROR: sendMessage",thisPlug.name,thisPlug.host);
             timeout = setTimeout(function() {
                 //socket.close();
                 if (retry_count > 1) {

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     "homebridge": ">=0.3.0"
   },
   "dependencies": {
-    "binary-parser": "~1.1.5"
+    "binary-parser": "~1.1.5",
+    "debug": "^2.2.0"
   },
   "main": "index.js",
   "author": "Dan Chlopek"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "homebridge-ecoplug",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "Homebridge plugin to control ECO Plugs by KAB",
   "license": "ISC",
   "repository": {


### PR DESCRIPTION
At my second property, I frequently have power failures and when it happens homebridge goes unresponsive and I need to reset everything to make it work again.  After a lot of digging around, I found that the problem was caused by the eco-plugs changing their ip address when the power was restored.  So I changed the discovery process to check the ip address it recorded for the eco-plug, and if it changes update the stored value.  I also changed how we were handling get status requests, and removed the function.  As the plugin poll's the device every 10 seconds it didn't make a difference. The only side effect is that if a plug is not responding, it doesn't show in Home app as not responding anymore until you try to control it.   I realize this is not ideal, but a good work around until I can find better method of telling Home that a device is not responding.